### PR TITLE
Use sonobuoy service to send results

### DIFF
--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -63,6 +63,8 @@ const (
 	sonobuoyProgressPortKey     = "SONOBUOY_PROGRESS_PORT"
 
 	sonobuoyDefaultConfigDir = "/tmp/sonobuoy/config"
+
+	sonobuoySvcName = "sonobuoy-aggregator"
 )
 
 var (
@@ -355,8 +357,8 @@ func generateAggregatorAndService(w io.Writer, cfg *GenConfig) error {
 				},
 				Env: []corev1.EnvVar{
 					{
-						Name:      "SONOBUOY_ADVERTISE_IP",
-						ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}},
+						Name:  "SONOBUOY_AGGREGATOR_SERVICE_NAME",
+						Value: sonobuoySvcName,
 					},
 				},
 				Resources: corev1.ResourceRequirements{
@@ -429,7 +431,7 @@ func generateAggregatorAndService(w io.Writer, cfg *GenConfig) error {
 		},
 	}
 	ser.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"})
-	ser.Name = "sonobuoy-aggregator"
+	ser.Name = sonobuoySvcName
 	ser.Namespace = cfg.Config.Namespace
 	ser.Labels = map[string]string{
 		"component":          "sonobuoy",

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -89,8 +89,8 @@ func LoadConfig(pathsToTry ...string) (*Config, error) {
 func (cfg *Config) Resolve() {
 	// Figure out what address we will tell pods to dial for aggregation
 	if cfg.Aggregation.AdvertiseAddress == "" {
-		if ip := os.Getenv("SONOBUOY_ADVERTISE_IP"); ip != "" {
-			cfg.Aggregation.AdvertiseAddress = fmt.Sprintf("[%v]:%d", ip, cfg.Aggregation.BindPort)
+		if svcName := os.Getenv("SONOBUOY_AGGREGATOR_SERVICE_NAME"); svcName != "" {
+			cfg.Aggregation.AdvertiseAddress = fmt.Sprintf("[%v]:%d", svcName, cfg.Aggregation.BindPort)
 		} else {
 			hostname, _ := os.Hostname()
 			if hostname != "" {

--- a/pkg/plugin/aggregation/run.go
+++ b/pkg/plugin/aggregation/run.go
@@ -113,7 +113,7 @@ func Run(client kubernetes.Interface, plugins []plugin.Interface, cfg plugin.Agg
 	}()
 
 	// AdvertiseAddress often has a port, split this off if so
-	advertiseAddress := cfg.AdvertiseAddress
+	advertiseAddress := cfg.AdvertiseAddress // sonobuoy-aggregator:8080
 	if host, _, err := net.SplitHostPort(cfg.AdvertiseAddress); err == nil {
 		advertiseAddress = host
 	}
@@ -249,6 +249,7 @@ func (a *Aggregator) RunAndMonitorPlugin(ctx context.Context, timeout time.Durat
 		ctxIngest, cancelIngest = context.WithTimeout(ctx, timeout+timeoutMonitoringOffset)
 	}
 
+	// address = sonobuoy-aggregator:8080
 	if err := p.Run(client, address, cert, aggregatorPod, progressPort, pluginResultDir); err != nil {
 		err := errors.Wrapf(err, "error running plugin %v", p.GetName())
 		logrus.Error(err)

--- a/pkg/plugin/driver/base.go
+++ b/pkg/plugin/driver/base.go
@@ -184,7 +184,7 @@ func (b *Base) workerEnvironment(hostname string, cert *tls.Certificate, progres
 		},
 		{
 			Name:  "AGGREGATOR_URL",
-			Value: hostname,
+			Value: hostname, // https://sonobuoy-aggregator:8080
 		},
 		{
 			Name:  "CA_CERT",

--- a/pkg/plugin/driver/job/job.go
+++ b/pkg/plugin/driver/job/job.go
@@ -142,6 +142,7 @@ func (p *Plugin) createPodDefinition(hostname string, cert *tls.Certificate, own
 
 // Run dispatches worker pods according to the Job's configuration.
 func (p *Plugin) Run(kubeclient kubernetes.Interface, hostname string, cert *tls.Certificate, ownerPod *v1.Pod, progressPort, resultDir string) error {
+	// hostname = sonobuoy-aggregator:8080
 	job := p.createPodDefinition(fmt.Sprintf("https://%s", hostname), cert, ownerPod, progressPort, resultDir)
 
 	secret, err := p.MakeTLSSecret(cert, ownerPod)

--- a/test/stress/stress_test.go
+++ b/test/stress/stress_test.go
@@ -1,3 +1,6 @@
+//go:build stress
+// +build stress
+
 /*
 Copyright 2018 Heptio Inc.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently sonobuoy worker uses pod ip to directly send results, which is not recommended by istio and k8s.

**Which issue(s) this PR fixes**
- Fixes #

**Special notes for your reviewer**:

**Release note**:
```
release-note
```
